### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Note that digraphs such as “ㄸ” and “ㅒ” are not assigned any separate
 
 이 글꼴로 입력하기 위해 다음의 수단을 이용할 수 있습니다:
 - [Oesol-key](https://github.com/ZyntharSekki/Oesol-key): [ZyntharSekki](https://github.com/ZyntharSekki) 님의 날개셋 입력기용 자판 배열.
-- [Oesol-Keyman](https://github.com/oysol/Oesol-Keyman): [oysol](https://github.com/oysol) 님의 Keyman 입력기용 자판 배열.
+- [Oysol-key](https://github.com/oysol/Oysol-key): [oysol](https://github.com/oysol) 님의 Keyman 입력기용 자판 배열.
 - [oysolscript](https://github.com/oysol/oysolscript): [oysol](https://github.com/oysol) 님의 Emacs용 Yale 로마자 표기법-외솔 풀어쓰기 간 변환기.
 - [아무넣](https://phost.gitlab.io/wt/am/): [피리](https://gitlab.com/phost) 님의 웹 입력기.
 - [oesolscript](https://bitbucket.org/novadh/oesolscript/src/master/): N. d. H. 님의 LaTeX 패키지.
@@ -62,7 +62,7 @@ Note that digraphs such as “ㄸ” and “ㅒ” are not assigned any separate
 
 You may take advantage of the following tools for input:
 - [Oesol-key](https://github.com/ZyntharSekki/Oesol-key): A keyboard layout for Nalgaeset Hangul Input by [ZyntharSekki](https://github.com/ZyntharSekki).
-- [Oesol-Keyman](https://github.com/oysol/Oesol-Keyman): A keyboard layout for Keyman by [oysol](https://github.com/oysol).
+- [Oysol-key](https://github.com/oysol/Oysol-key/): A keyboard layout for Keyman by [oysol](https://github.com/oysol).
 - [oysolscript](https://github.com/oysol/oysolscript): A Yale romanization to Oesol disassembled Hangul converter for Emacs by [oysol](https://github.com/oysol).
 - [아무넣](https://phost.gitlab.io/wt/am/): A web IME by [피리](https://gitlab.com/phost).
 - [oesolscript](https://bitbucket.org/novadh/oesolscript/src/master/): A LaTeX package by N. d. H.


### PR DESCRIPTION
Oesol-Keyman은 단순히 제가 리눅스에서 외솔 입력 장치가 필요하여서 만든 것이었습니다.
따라서 Oesol-key의 이름을 살짝 변경하여 Oesol-Keyman으로 하는 것이 적절하다고 판단하였습니다.

하지만 지금은 입력 방식 자체를 바꿨습니다.

유니코드 중에 Breve라고 하여 ˘가 있더군요.
이것을 짧은 ㅡ를 대신하여 쿼티 자판 기준으로 p에 배치하고, 기존에 짧은 ㅜ와 짧은 ㅗ를 배치했었던 키를 쿼티 자판과 같게 하여 확장성을 높였습니다.

이것과 모음을 연속해서 누르면 짧은 ㅗ, 짧은 ㅜ, 짧은 ㅡ, 짧은 ㅣ를 누를 수 있게 하였습니다. 순서는 상관없습니다.
다만 제가 지금 윈도우컴이 없어서 그것을 컴파일할 수 있는 상황이 아니라서 소스만 수정했습니다.

그래서 이름이 유사한데, 자판 배열이 다르면, 혼동을 빚을 수 있다 싶어서 해당 키 배열의 이름을 수정하였습니다.

그리고 øsol-key라고 하여, 음운론적 특성을 살린 키 배열도 연구 중이지만 실험적 성격이라 해당 리드미 파일에는 포함하지 않는 것이 적절하다고 판단하였습니다.

그뿐만 아니라, Keyman 배열 중에 IPA를 편히 입력할 수 있게 만들어주는 프로젝트가 있습니다. 그게 참 인상 깊었고, 저는 그것을 이용하여, IPA를 입력하는 방식에 착안하여 외솔 풀어쓰기체를 입력할 수 있도록 하는 방안도 생각 중이지만, 실용성이 있을지는 모르겠습니다.